### PR TITLE
correction in minesweeper.c

### DIFF
--- a/minesweeper.c
+++ b/minesweeper.c
@@ -179,7 +179,7 @@ static void setup_playfield(Minesweeper* minesweeper_state) {
     int rand_y = rand() % PLAYFIELD_HEIGHT;
     // make sure first guess isn't a mine
     if (minesweeper_state->minefield[rand_x][rand_y] == FieldEmpty &&
-       (minesweeper_state->cursor_x != rand_x && minesweeper_state->cursor_y != rand_y )) {
+       (minesweeper_state->cursor_x != rand_x || minesweeper_state->cursor_y != rand_y )) {
        minesweeper_state->minefield[rand_x][rand_y] = FieldMine;
        mines_left--;
     }


### PR DESCRIPTION
As I understand:

while(mines_left > 0) {
    int rand_x = rand() % PLAYFIELD_WIDTH;
    int rand_y = rand() % PLAYFIELD_HEIGHT;
    // make sure first guess isn't a mine
    if (minesweeper_state->minefield[rand_x][rand_y] == FieldEmpty &&
       (minesweeper_state->cursor_x != rand_x || minesweeper_state->cursor_y != rand_y )) {
       minesweeper_state->minefield[rand_x][rand_y] = FieldMine;
       mines_left--;
    }
  }
cursor_x and cursor_y are the current position of the "cursor" and the position where the first click was made. Now there is made a check, if the mine, that wants to be created, is not in the same column and not in the same row as the mine that wants to be placed. But for us it is totally fine, if the mine is either not in the same row !or! not in the same column. That is why "$$" must be changed to "||".

I tried to find in the internet a way to compile the code and test it. I did not find a good instruction for that. Is there any possibility to check the code on the computer or I always have to do it on the flipper? What program do you use for compiling the code? Best regards,
Mikhail