### PR TITLE
fix build for firmware v0.83.1

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -1,7 +1,7 @@
 App(
     appid="minesweeper",
     name="Minesweeper",
-    apptype=FlipperAppType.PLUGIN,
+    apptype=FlipperAppType.EXTERNAL,
     entry_point="minesweeper_app",
     cdefines=["APP_MINESWEEPER"],
     requires=["gui"],

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -75,7 +75,7 @@ static void input_callback(InputEvent* input_event, FuriMessageQueue* event_queu
 }
 
 static void render_callback(Canvas* const canvas, void* ctx) {
-    const Minesweeper* minesweeper_state = acquire_mutex((ValueMutex*)ctx, 25);
+    const Minesweeper* minesweeper_state = ctx;
     if (minesweeper_state == NULL) {
       return;
     }
@@ -163,7 +163,6 @@ static void render_callback(Canvas* const canvas, void* ctx) {
 
     furi_string_free(mineStr);
     furi_string_free(timeStr);
-    release_mutex((ValueMutex*)ctx, minesweeper_state);
 }
 
 static void setup_playfield(Minesweeper* minesweeper_state) {
@@ -381,19 +380,13 @@ int32_t minesweeper_app(void* p) {
   // setup
   minesweeper_state_init(minesweeper_state);
 
-  ValueMutex state_mutex;
-  if (!init_mutex(&state_mutex, minesweeper_state, sizeof(minesweeper_state))) {
-      FURI_LOG_E("Minesweeper", "cannot create mutex\r\n");
-      free(minesweeper_state);
-      return 255;
-  }
   // BEGIN IMPLEMENTATION
 
   // Set system callbacks
   ViewPort* view_port = view_port_alloc();
-  view_port_draw_callback_set(view_port, render_callback, &state_mutex);
+  view_port_draw_callback_set(view_port, render_callback, minesweeper_state);
   view_port_input_callback_set(view_port, input_callback, event_queue);
-  minesweeper_state->timer = furi_timer_alloc(timer_callback, FuriTimerTypeOnce, &state_mutex);
+  minesweeper_state->timer = furi_timer_alloc(timer_callback, FuriTimerTypeOnce, minesweeper_state);
 
   // Open GUI and register view_port
   Gui* gui = furi_record_open("gui");
@@ -402,7 +395,6 @@ int32_t minesweeper_app(void* p) {
   PluginEvent event;
   for (bool processing = true; processing;) {
     FuriStatus event_status = furi_message_queue_get(event_queue, &event, 100);
-    Minesweeper* minesweeper_state = (Minesweeper*)acquire_mutex_block(&state_mutex);
     if(event_status == FuriStatusOk) {
       // press events
       if(event.type == EventTypeKey) {
@@ -491,14 +483,12 @@ int32_t minesweeper_app(void* p) {
       ;
     }
     view_port_update(view_port);
-    release_mutex(&state_mutex, minesweeper_state);
   }
   view_port_enabled_set(view_port, false);
   gui_remove_view_port(gui, view_port);
   furi_record_close("gui");
   view_port_free(view_port);
   furi_message_queue_free(event_queue);
-  delete_mutex(&state_mutex);
   furi_timer_free(minesweeper_state->timer);
   free(minesweeper_state);
 


### PR DESCRIPTION
`apptype` now must be `EXTERNAL`.

Removed mutexes. Looks like they are not needed anymore.
* https://www.reddit.com/r/FlipperZeroDev/comments/12porzt/scons_no_sconstruct_file_found/
* https://github.com/flipperdevices/flipperzero-firmware/blob/dev/applications/examples/example_thermo/example_thermo.c